### PR TITLE
Updates to make plugin not send pages for warnings or errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 nosetests.xml
 coverage.xml
 .venv
+venv/*
 *.swp
 *.swo
 *~
@@ -10,5 +11,7 @@ coverage.xml
 
 .eggs/
 _build/
+build/*
+dist/*
 *.pyc
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -3,9 +3,20 @@ Cabot Pagerduty Plugin
 This is a pagerduty alert plugin for Cabot.
 
 ### Usage
-This plugin is used for alerting to Pagerduty from Cabot. The implementation is a hack, because of the current pagerduty design. The alerting parameters are configured on a per-user basis and not per service. (hipchat, email, phone-no etc.)
+This plugin is used for alerting to Pagerduty from Cabot. The implementation is
+a hack, because of the current pagerduty design. The alerting parameters are
+configured on a per-user basis and not per service. (hipchat, email, phone-no etc.)
 
-Once you install this plugin,
-* add a user dedicated to pagerduty
-* configure this user as "fallback duty officer"
-* configure the service key in this user's profile
+###Once you install this plugin:
+####In PagerDuty:
+* Create a V1 API Token. This will be needed for the Cabot configuration
+value ```PAGERDUTY_API_TOKEN```
+* Create a new Service. Add a Generic API integration. An Integration or
+Service Key will be generated to be used for creating the specific user
+to link to the PagerDuty escalation policy. Which users are alerted by
+Pagerduty will be configured as part of this policy.
+
+####In Cabot:
+* Add a user dedicated to a specific Pagerduty Escalation Policy
+* Configure this user as "fallback duty officer"
+* Configure the service key in this user's profile

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Service Key will be generated to be used for creating the specific user
 to link to the PagerDuty escalation policy. Which users are alerted by
 Pagerduty will be configured as part of this policy.
 
+####In Cabot Configuration:
+* Set ```PAGERDUTY_API_TOKEN``` to value configured in Pagerduty
+* Set ```PAGERDUTY_SUBDOMAIN``` for Pagerduty API endpoint
+* If alerts should be sent to Pagerduty for a service status check other than
+critical, configure a comma-separated list for ```PAGERDUTY_ALERT_STATUS```
+e.g. 'ERROR,CRITICAL'
+
 ####In Cabot:
 * Add a user dedicated to a specific Pagerduty Escalation Policy
 * Configure this user as "fallback duty officer"

--- a/cabot_alert_pagerduty/models.py
+++ b/cabot_alert_pagerduty/models.py
@@ -28,7 +28,7 @@ class PagerdutyAlert(AlertPlugin):
     def send_alert(self, service, users, duty_officers):
         """Implement your send_alert functionality here."""
 
-        if not self._service_alertable(service):
+        if not _service_alertable(service):
             return
 
         subdomain = os.environ.get('PAGERDUTY_SUBDOMAIN')
@@ -64,18 +64,18 @@ class PagerdutyAlert(AlertPlugin):
             except Exception, exp:
                 logger.exception('Error invoking pagerduty: %s' % str(exp))
 
-    def _service_alertable(self, service):
+def _service_alertable(service):
 
-        alertable_status = [service.ERROR_STATUS, service.CRITICAL_STATUS]
+    alertable_status = [service.ERROR_STATUS, service.CRITICAL_STATUS]
 
-        if service.overall_status in alertable_status:
-            return True
+    if service.overall_status in alertable_status:
+        return True
 
-        if service.overall_status == service.PASSING_STATUS and \
-            service.old_overall_status in alertable_status:
-            return True
+    if service.overall_status == service.PASSING_STATUS and \
+        service.old_overall_status in alertable_status:
+        return True
 
-        return False
+    return False
 
 
 class PagerdutyAlertUserData(AlertPluginUserData):

--- a/cabot_alert_pagerduty/models.py
+++ b/cabot_alert_pagerduty/models.py
@@ -26,11 +26,12 @@ class PagerdutyAlert(AlertPlugin):
     name = "Pagerduty"
     author = "Mahendra M"
 
-    
-    def __init__(self, *args, **kwargs):
-        super(PagerdutyAlert, self).__init__(self, *args, **kwargs)
+    @property
+    def alert_status_list(self):
+        if not hasattr(self, '_alert_status_list'):
+            self._alert_status_list = _gather_alertable_status()
 
-        self.alert_status_list = _gather_alertable_status()
+        return self._alert_status_list
 
     def send_alert(self, service, users, duty_officers):
         """Implement your send_alert functionality here."""

--- a/cabot_alert_pagerduty/models.py
+++ b/cabot_alert_pagerduty/models.py
@@ -28,6 +28,9 @@ class PagerdutyAlert(AlertPlugin):
     def send_alert(self, service, users, duty_officers):
         """Implement your send_alert functionality here."""
 
+        if not self._service_alertable(service):
+            return
+
         subdomain = os.environ.get('PAGERDUTY_SUBDOMAIN')
         api_token = os.environ.get('PAGERDUTY_API_TOKEN')
 
@@ -60,6 +63,19 @@ class PagerdutyAlert(AlertPlugin):
                                             incident_key=incident_key)
             except Exception, exp:
                 logger.exception('Error invoking pagerduty: %s' % str(exp))
+
+    def _service_alertable(self, service):
+
+        alertable_status = [service.ERROR_STATUS, service.CRITICAL_STATUS]
+
+        if service.overall_status in alertable_status:
+            return True
+
+        if service.overall_status == service.PASSING_STATUS and \
+            service.old_overall_status in alertable_status:
+            return True
+
+        return False
 
 
 class PagerdutyAlertUserData(AlertPluginUserData):

--- a/cabot_alert_pagerduty/models.py
+++ b/cabot_alert_pagerduty/models.py
@@ -64,9 +64,10 @@ class PagerdutyAlert(AlertPlugin):
             except Exception, exp:
                 logger.exception('Error invoking pagerduty: %s' % str(exp))
 
+
 def _service_alertable(service):
 
-    alertable_status = [service.ERROR_STATUS, service.CRITICAL_STATUS]
+    alertable_status = [service.CRITICAL_STATUS]
 
     if service.overall_status in alertable_status:
         return True

--- a/cabot_alert_pagerduty/models.py
+++ b/cabot_alert_pagerduty/models.py
@@ -27,15 +27,15 @@ class PagerdutyAlert(AlertPlugin):
     author = "Mahendra M"
 
     
-    def __init__(self):
-        super(PagerdutyAlert, self).__init__()
+    def __init__(self, *args, **kwargs):
+        super(PagerdutyAlert, self).__init__(self, *args, **kwargs)
 
         self.alert_status_list = _gather_alertable_status()
 
     def send_alert(self, service, users, duty_officers):
         """Implement your send_alert functionality here."""
 
-        if not _service_alertable(service):
+        if not self._service_alertable(service):
             return
 
         subdomain = os.environ.get('PAGERDUTY_SUBDOMAIN')
@@ -71,20 +71,17 @@ class PagerdutyAlert(AlertPlugin):
             except Exception, exp:
                 logger.exception('Error invoking pagerduty: %s' % str(exp))
 
+    def _service_alertable(self, service):
+        """ Evaluate service for alertable status """
 
-def _service_alertable(service):
-    """ Evaluate service for alertable status """
+        if service.overall_status in self.alert_status_list:
+            return True
 
-    alertable_status = [service.CRITICAL_STATUS]
+        if service.overall_status == service.PASSING_STATUS and \
+            service.old_overall_status in self.alert_status_list:
+            return True
 
-    if service.overall_status in alertable_status:
-        return True
-
-    if service.overall_status == service.PASSING_STATUS and \
-        service.old_overall_status in alertable_status:
-        return True
-
-    return False
+        return False
 
 
 def _gather_alertable_status():

--- a/cabot_alert_pagerduty/models.py
+++ b/cabot_alert_pagerduty/models.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import logging
 import os
 import pygerduty
@@ -24,6 +25,12 @@ class PagerdutyAlert(AlertPlugin):
     '''
     name = "Pagerduty"
     author = "Mahendra M"
+
+    
+    def __init__(self):
+        super(PagerdutyAlert, self).__init__()
+
+        self.alert_status_list = _gather_alertable_status()
 
     def send_alert(self, service, users, duty_officers):
         """Implement your send_alert functionality here."""
@@ -66,6 +73,7 @@ class PagerdutyAlert(AlertPlugin):
 
 
 def _service_alertable(service):
+    """ Evaluate service for alertable status """
 
     alertable_status = [service.CRITICAL_STATUS]
 
@@ -78,6 +86,11 @@ def _service_alertable(service):
 
     return False
 
+
+def _gather_alertable_status():
+    alert_status_list = os.environ.get('PAGERDUTY_ALERT_STATUS', 'CRITICAL').split(',')
+
+    return alert_status_list
 
 class PagerdutyAlertUserData(AlertPluginUserData):
     name = "Pagerduty Plugin"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-__VERSION__ = '1.0.1'
+__VERSION__ = '1.0.2'
 
 setup(name='cabot-alert-pagerduty',
       version=__VERSION__,

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 from setuptools import setup
 
 __VERSION__ = '1.0.1'

--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,7 @@ setup(name='cabot-alert-pagerduty',
       install_requires=[
         'pygerduty==0.14',
       ],
+      tests_require=[
+        'cabot',
+      ],
      )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,2 @@
-#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+from __future__ import absolute_import

--- a/tests/bootstrap_tests.py
+++ b/tests/bootstrap_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.conf import settings
 settings.configure()
 settings.JENKINS_USER = 'Test'

--- a/tests/bootstrap_tests.py
+++ b/tests/bootstrap_tests.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+settings.configure()
+settings.JENKINS_USER = 'Test'
+settings.JENKINS_PASS = 'Test'
+settings.GRAPHITE_API = 'Test'
+settings.GRAPHITE_USER = 'Test'
+settings.GRAPHITE_PASS = 'Test'
+settings.GRAPHITE_FROM = 'Test'

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,2 +1,2 @@
-#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+from __future__ import absolute_import

--- a/tests/unit/test_service_status_check.py
+++ b/tests/unit/test_service_status_check.py
@@ -2,12 +2,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+import os
 import unittest
 
 import tests.bootstrap_tests
 
 from cabot.cabotapp.models import Service
+from cabot_alert_pagerduty.models import PagerdutyAlert
 from cabot_alert_pagerduty.models import _service_alertable
+from cabot_alert_pagerduty.models import _gather_alertable_status
 
 class TestServiceStatusChecks(unittest.TestCase):
 
@@ -31,6 +34,30 @@ class TestServiceStatusChecks(unittest.TestCase):
         service.overall_status = service.ERROR_STATUS
         self.assertFalse(_service_alertable(service))
 
+    def test_default_critical_status(self):
+
+        os.environ.pop('PAGERDUTY_ALERT_STATUS', None)
+
+        default_alert_status = ['CRITICAL']
+        self.assertEqual(default_alert_status, _gather_alertable_status())
+
+    def test_default_status_in_plugin(self):
+
+        os.environ.pop('PAGERDUTY_ALERT_STATUS', None)
+
+        default_alert_status = ['CRITICAL']
+        plugin = PagerdutyAlert()
+
+        self.assertEqual(default_alert_status, plugin.alert_status_list)
+
+    def test_configured_status_in_plugin(self):
+
+        os.environ['PAGERDUTY_ALERT_STATUS'] = 'CRITICAL,WARNING'
+
+        default_alert_status = ['CRITICAL', 'WARNING']
+        plugin = PagerdutyAlert()
+
+        self.assertEqual(default_alert_status, plugin.alert_status_list)
 
 if __name__ == '__main__':
     SUITE = unittest.TestLoader().loadTestsFromTestCase(TestServiceStatusChecks)

--- a/tests/unit/test_service_status_check.py
+++ b/tests/unit/test_service_status_check.py
@@ -8,7 +8,7 @@ import tests.bootstrap_tests
 
 from cabot.cabotapp.models import Service
 from cabot_alert_pagerduty.models import PagerdutyAlert
-from cabot_alert_pagerduty.models import _service_alertable
+# from cabot_alert_pagerduty.models import _service_alertable
 from cabot_alert_pagerduty.models import _gather_alertable_status
 
 class TestServiceStatusChecks(unittest.TestCase):
@@ -20,18 +20,22 @@ class TestServiceStatusChecks(unittest.TestCase):
         """ A service with a critical status is alertable """
         service = Service()
 
+        plugin = PagerdutyAlert()
+
         service.overall_status = service.CRITICAL_STATUS
-        self.assertTrue(_service_alertable(service))
+        self.assertTrue(plugin._service_alertable(service))
 
     def test_non_critical_alertable(self):
         """ A non-critical service status does not alert """
         service = Service()
 
+        plugin = PagerdutyAlert()
+
         service.overall_status = service.WARNING_STATUS
-        self.assertFalse(_service_alertable(service))
+        self.assertFalse(plugin._service_alertable(service))
 
         service.overall_status = service.ERROR_STATUS
-        self.assertFalse(_service_alertable(service))
+        self.assertFalse(plugin._service_alertable(service))
 
     def test_default_critical_status(self):
 
@@ -53,10 +57,10 @@ class TestServiceStatusChecks(unittest.TestCase):
 
         os.environ['PAGERDUTY_ALERT_STATUS'] = 'CRITICAL,WARNING'
 
-        default_alert_status = ['CRITICAL', 'WARNING']
+        custom_alert_status = ['CRITICAL', 'WARNING']
         plugin = PagerdutyAlert()
 
-        self.assertEqual(default_alert_status, plugin.alert_status_list)
+        self.assertEqual(custom_alert_status, plugin.alert_status_list)
 
 if __name__ == '__main__':
     SUITE = unittest.TestLoader().loadTestsFromTestCase(TestServiceStatusChecks)

--- a/tests/unit/test_service_status_check.py
+++ b/tests/unit/test_service_status_check.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import unittest
+
+from cabot_alert_pagerduty.models import _service_alertable
+# from mappers.MapperLocator import find_mapper, MapperLookupError
+
+class TestServiceStatusChecks(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_valid_mapping(self):
+        """ Proper class is returned via qualified name string """
+
+        # from mappers.BaseMapper import BaseMapper
+
+        # base_mapper_name = 'mappers.BaseMapper.BaseMapper'
+
+        # base_mapper = find_mapper(base_mapper_name)
+
+        self.assertEqual(True, True)
+
+    # def test_non_qualified_mapper_name(self):
+    #     """ A mapper name that is not fully qualified results in an error """
+
+    #     mapper_name = 'BaseMapper'
+
+    #     with self.assertRaises(MapperLookupError) as error:
+    #         find_mapper(mapper_name)
+
+    #     err_message = 'Incomplete class name specified: BaseMapper'
+    #     self.assertEqual(str(error.exception), err_message)
+
+    # def test_invalid_mapper_module(self):
+    #     """ Invalid module name generate error when attempting to load """
+
+    #     mapper_name = 'mapperz.BaseMapper'
+
+    #     with self.assertRaises(MapperLookupError) as error:
+    #         find_mapper(mapper_name)
+
+    #     err_message = 'mapperz module cannot be found for class BaseMapper'
+    #     self.assertEqual(str(error.exception), err_message)
+
+    # def test_invalid_mapper_class_name(self):
+    #     """ Invalid class name generates error when attempting to load """
+
+    #     mapper_name = 'mappers.BaseMapper.LOLWut'
+
+    #     with self.assertRaises(MapperLookupError) as error:
+    #         find_mapper(mapper_name)
+
+    #     err_msg = 'LOLWut class cannot be found in module mappers.BaseMapper'
+    #     self.assertEqual(str(error.exception), err_msg)
+
+
+if __name__ == '__main__':
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(TestServiceStatusChecks)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/tests/unit/test_service_status_check.py
+++ b/tests/unit/test_service_status_check.py
@@ -4,57 +4,32 @@ from __future__ import absolute_import
 
 import unittest
 
+import tests.bootstrap_tests
+
+from cabot.cabotapp.models import Service
 from cabot_alert_pagerduty.models import _service_alertable
-# from mappers.MapperLocator import find_mapper, MapperLookupError
 
 class TestServiceStatusChecks(unittest.TestCase):
 
     def setUp(self):
         pass
 
-    def test_valid_mapping(self):
-        """ Proper class is returned via qualified name string """
+    def test_critical_alertable(self):
+        """ A service with a critical status is alertable """
+        service = Service()
 
-        # from mappers.BaseMapper import BaseMapper
+        service.overall_status = service.CRITICAL_STATUS
+        self.assertTrue(_service_alertable(service))
 
-        # base_mapper_name = 'mappers.BaseMapper.BaseMapper'
+    def test_non_critical_alertable(self):
+        """ A non-critical service status does not alert """
+        service = Service()
 
-        # base_mapper = find_mapper(base_mapper_name)
+        service.overall_status = service.WARNING_STATUS
+        self.assertFalse(_service_alertable(service))
 
-        self.assertEqual(True, True)
-
-    # def test_non_qualified_mapper_name(self):
-    #     """ A mapper name that is not fully qualified results in an error """
-
-    #     mapper_name = 'BaseMapper'
-
-    #     with self.assertRaises(MapperLookupError) as error:
-    #         find_mapper(mapper_name)
-
-    #     err_message = 'Incomplete class name specified: BaseMapper'
-    #     self.assertEqual(str(error.exception), err_message)
-
-    # def test_invalid_mapper_module(self):
-    #     """ Invalid module name generate error when attempting to load """
-
-    #     mapper_name = 'mapperz.BaseMapper'
-
-    #     with self.assertRaises(MapperLookupError) as error:
-    #         find_mapper(mapper_name)
-
-    #     err_message = 'mapperz module cannot be found for class BaseMapper'
-    #     self.assertEqual(str(error.exception), err_message)
-
-    # def test_invalid_mapper_class_name(self):
-    #     """ Invalid class name generates error when attempting to load """
-
-    #     mapper_name = 'mappers.BaseMapper.LOLWut'
-
-    #     with self.assertRaises(MapperLookupError) as error:
-    #         find_mapper(mapper_name)
-
-    #     err_msg = 'LOLWut class cannot be found in module mappers.BaseMapper'
-    #     self.assertEqual(str(error.exception), err_msg)
+        service.overall_status = service.ERROR_STATUS
+        self.assertFalse(_service_alertable(service))
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_service_status_check.py
+++ b/tests/unit/test_service_status_check.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import os
 import unittest


### PR DESCRIPTION
Cabot philosophy indicates pages should be sent for a critical alerts. This plugin alerts for all service status levels.
